### PR TITLE
Fix an off-by-one error when using range as a bit width. 

### DIFF
--- a/quantumrandom/__init__.py
+++ b/quantumrandom/__init__.py
@@ -85,7 +85,7 @@ def randint(min=0, max=10, generator=None):
     if generator is None:
         generator = cached_generator()
 
-    source_bits = int(math.ceil(math.log(range, 2)))
+    source_bits = int(math.ceil(math.log(range + 1, 2)))
     source_size = int(math.ceil(source_bits / float(INT_BITS)))
     source_max = 2**(source_size * INT_BITS) - 1
 


### PR DESCRIPTION
This was causing a hang when range == 1,
and would have also resulted in a value of 65536 never beeing seen
in a request like randint(0,65536).

Sorry this took so long, I've been sick and circumstances prevented me from being able to push.
