### PR TITLE
Change range behavior to conform with random.randint()

### DIFF
--- a/quantumrandom/__init__.py
+++ b/quantumrandom/__init__.py
@@ -101,7 +101,7 @@ def hex(array_length=100, block_size=100):
 def randint(min=0, max=10, generator=None):
     """Return an int between min and max. If given, takes from generator instead.
     This can be useful to reuse the same cached_generator() instance over multiple calls."""
-    rand_range = max - min
+    rand_range = (max + 1) - min
     if rand_range == 0:
         # raise ValueError("range cannot be zero")  # meh
         return min


### PR DESCRIPTION
The practical behavior of `quantumrandom.randint(min, max)` is that it returns numbers in the range of min..(max - 1). This means it works like the python built-in `range()` function, but it deviates from the behavior of `random.randint()` which I assume this module's method is intended to replicate. You can see this discrepancy in action with the following code snippet:

    import quantumrandom, random, time

    while True:
        qrand = int(quantumrandom.randint(0,1)) # forcing to int for python3
        rand = random.randint(0,1)
        print(qrand, rand)
        time.sleep(0.1)

`qrand` will only ever print 0, while `rand` will print either 0 or 1.

Implementing this PR will probably break existing scripts that use this module, but the confusion between the `random` and `quantumrandom` versions of the method will no doubt lead to unintentional errors due to bad assumptions. If the behavior isn't changed, I think the documentation should at least mention this issue explicitly.

