### PR TITLE
Changed the request method to 'requests.get()' instead of 'urllib.urlopen()' to fix SSL issues.

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,6 @@
 # These are supported funding model platforms
 
-github: [breadbored]
+# Waiting to be approved
+#github: [breadbored]
+
+patreon: breadbored

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# These are supported funding model platforms
+
+github: [breadbored]

--- a/quantumrandom/__init__.py
+++ b/quantumrandom/__init__.py
@@ -24,21 +24,20 @@ http://qrng.anu.edu.au
 """
 
 import binascii
+import requests
 import math
 import sys
 import six
 try:
     from urllib.parse import urlencode
-    from urllib.request import urlopen
 except ImportError:
     from urllib import urlencode
-    from urllib2 import urlopen
 try:
     import json
 except ImportError:
     import simplejson as json
 
-VERSION = '1.9.0'
+VERSION = '2.0.0'
 URL = 'https://qrng.anu.edu.au/API/jsonI.php'
 DATA_TYPES = ['uint16', 'hex16']
 MAX_LEN = 1024
@@ -66,7 +65,7 @@ def get_data(data_type='uint16', array_length=1, block_size=1):
 
 if sys.version_info[0] == 2:
     def get_json(url):
-        return json.loads(urlopen(url).read(), object_hook=_object_hook)
+        return requests.get(url, verify=False).json()
 
     def _object_hook(obj):
         """We are only dealing with ASCII characters"""
@@ -85,7 +84,7 @@ if sys.version_info[0] == 2:
                 return default
 else:
     def get_json(url):
-        return json.loads(urlopen(url).read().decode('ascii'))
+        return requests.get(url, verify=False).json()
 
 
 def binary(array_length=100, block_size=100):

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,13 @@
 from setuptools import setup, find_packages
 import sys
 
-version = '1.9.0'
+version = '2.0.0'
 
 f = open('README.rst')
 long_description = f.read()
 f.close()
 
-requires = ['six']
+requires = ['six', 'requests']
 if sys.version_info[0] == 2:
     if sys.version_info[1] in (4, 5):
         requires.append('simplejson < 2.0.10')


### PR DESCRIPTION
The ANU server has an SSL certificate that cannot be verified.

To fix this, I replaced `urllib.open()` with `requests.get()` so that I could use the `verify=False` flag. Without this flag the generator could not be fixed on our end without breaking other modules that require SSL (for example, pymongo).

This is working for me, hopefully it works for others.